### PR TITLE
Errata/202104 fix setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Azure Confidential Compute - Open Enclave Sample
+
 This is the sample that was used in [my blog post](https://thomasvanlaere.com/posts/2020/06/azure-confidential-computing/) on Azure Confidential Compute. I based this sample on the existing [Open Enclave](https://openenclave.io/sdk/) samples to try to get a better understanding of how Intel SGX and Open Enclave work. It basically performs the addition of two numbers inside of an enclave, nothing fancy.
 
 I highly recommend that you follow along the blog post since it assumes that you have Visual Studio Code's Remote Development extension installed and configured.
@@ -6,6 +7,25 @@ I highly recommend that you follow along the blog post since it assumes that you
 The sample can be improved upon since the numbers which are used to perform the addition are unencrypted in the host part of our application. You can imagine that you might want to use some sort of encrypted version of numberA and numberB and decrypt them within the enclave to perform the addition securely.
 
 ## Deploy an Azure Confidential Compute VM
+
+The [Azure Linux Custom Script Extension Version 2](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux) will attempt to download and execute the "```setup.sh```" script, which is included in "```azure```" directory, during the deployment.
+
+The "```setup.sh```" script perform the following tasks:
+
+- Configure APT Repositories
+- Download the Intel SGX driver
+- Install OpenEnclave 0.9.0 and its dependencies
+  - Released 24 april 2020
+- Install CMake 3.17.2
+
 Click the button to deploy a DCsv2-series VM, equiped with Intel SGX technology.
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FThomVanL%2Facc-openenclave-sample%2Fmaster%2Fazure%2Fazuredeploy.json)
+
+## Connecting via VS Code
+
+Visual Studio Code has quite a few wonderful extensions, one of them will allow us to use our SGX machine's capabilities as if we were using it as a local dev box! Open up your extensions in VS Code, search for "```ms-vscode-remote.vscode-remote-extensionpack```" and go ahead and install it.
+
+Once installed you can connect to your SGX virtual machine by opening the command palette (ctrl/⌘-shift-P), typing "```Remote-SSH: Connect to Host```" and selecting "```+ Add new host```". You will be prompted to enter the SSH command, which you can retrieve from your Azure deployment output via the Azure Portal, it should be along the lines of "```ssh <username>@<public_ip>```". Once you have gotten confirmation that the host has been added, run "```Remote-SSH: Connect to Host```" once more and select the public IP from the list. A new VS Code window will pop up and ask you for your password. You should now be connected to your SGX VM.
+
+Copy the "```SecretCalc```" directory to the VM and open the folder with VS Code (while still being remotely connected to your SGX VM), go ahead and install the recommended extensions. You should be able to launch (F5) the application with or without the extensions, although installing them should allow you to use the debugger.

--- a/SecretCalc/.vscode/extensions.json
+++ b/SecretCalc/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "ms-vscode.PowerShell",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools"
+    ]
+}

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -170,6 +170,30 @@
             }
         },
         {
+            "name": "[concat(parameters('virtualMachines_name'),'/', 'setupscript')]",
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "location": "[parameters('confidentialComputeRegion')]",
+            "apiVersion": "2019-03-01",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('virtualMachines_name')))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.1",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "skipDos2Unix": false,
+                    "timestamp": 1
+                },
+                "protectedSettings": {
+                    "fileUris": [ "https://raw.githubusercontent.com/ThomVanL/blog-acc-openenclave-sample/master/azure/setup.sh" ],
+                    "commandToExecute": "sh setup.sh",
+                    "managedIdentity": {}
+                }
+            }
+        },
+        {
             "type": "Microsoft.Network/networkInterfaces",
             "apiVersion": "2020-04-01",
             "name": "[parameters('networkInterface_name')]",

--- a/azure/setup.sh
+++ b/azure/setup.sh
@@ -39,7 +39,7 @@ echo "OpenEnclave 0.9.0 (24 april 2020) and dependencies: installing.."
 apt-get -qq -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client=1.4 open-enclave=0.9.0 >/dev/null
 echo "OpenEnclave 0.9.0 (24 april 2020) and dependencies: installed!"
 
-echo "CMAKE: installing version 3.17.2!"
+echo "CMake: installing version 3.17.2!"
 wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.sh
 chmod u+x cmake-3.17.2-Linux-x86_64.sh
 mkdir /opt/cmake
@@ -48,4 +48,4 @@ ln -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 ln -s /opt/cmake/bin/cpack /usr/local/bin/cpack
 ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest
-echo "CMAKE: installed!"
+echo "CMake: installed!"

--- a/azure/setup.sh
+++ b/azure/setup.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+
+# Azure Confidential Computing & OpenEnclave Sample
+#
+# See blog post: https://thomasvanlaere.com/posts/2020/06/azure-confidential-computing/
+#
+# This script will install components in order to
+# run a very simple OpenEnclave sample. The sample was written for OpenEnclave 0.9.0
+# and will install some other dependencies from when my blog post was written (June 2020).
+
+echo "APT Repositories: configuring.."
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
+wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add - > /dev/null 2>&1
+
+echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list
+wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - > /dev/null 2>&1
+
+echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | sudo tee /etc/apt/sources.list.d/msprod.list
+wget -qO - https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add - > /dev/null 2>&1
+
+apt-get update -qq >/dev/null
+echo "APT Repositories: configured!"
+
+if [ -z '$(dmesg | grep -i intel_sgx)' ]; then
+    echo "SGX driver: installing.."
+    apt-get -qq -y install dkms >/dev/null
+
+    # List of other SGX drivers versions: https://01.org/intel-software-guard-extensions/downloads
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.4/linux/distro/ubuntuServer18.04/sgx_linux_x64_driver_1.21.bin -O sgx_linux_x64_driver.bin
+    chmod +x sgx_linux_x64_driver.bin
+    ./sgx_linux_x64_driver.bin
+    echo "SGX driver: installed!"
+else
+    echo "SGX driver: already installed!"
+fi
+
+echo "OpenEnclave 0.9.0 (24 april 2020) and dependencies: installing.."
+apt-get -qq -y install clang-7 libssl-dev gdb libsgx-enclave-common libsgx-enclave-common-dev libprotobuf10 libsgx-dcap-ql libsgx-dcap-ql-dev az-dcap-client=1.4 open-enclave=0.9.0 >/dev/null
+echo "OpenEnclave 0.9.0 (24 april 2020) and dependencies: installed!"
+
+echo "CMAKE: installing version 3.17.2!"
+wget https://github.com/Kitware/CMake/releases/download/v3.17.2/cmake-3.17.2-Linux-x86_64.sh
+chmod u+x cmake-3.17.2-Linux-x86_64.sh
+mkdir /opt/cmake
+sh -c "DEBIAN_FRONTEND=noninteractive ./cmake-3.17.2-Linux-x86_64.sh --prefix=/opt/cmake --skip-license"
+ln -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake
+ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/cpack /usr/local/bin/cpack
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest
+echo "CMAKE: installed!"


### PR DESCRIPTION
I was made aware that the sample did not run properly. I believe this is due to the fact that newer versions of OpenEnclave have introduced some breaking changes since I wrote my blog post. 

When deploying the SGX VM on Azure, a script (```setup.sh```) will now set up the environment:

- Configure APT Repositories
- Download the Intel SGX driver
- Install OpenEnclave 0.9.0 and its dependencies
  - Released 24 april 2020
- Install CMake 3.17.2

